### PR TITLE
Possible solution for backward compatibility with iOS v10.

### DIFF
--- a/src/modal-datetimepicker.ios.ts
+++ b/src/modal-datetimepicker.ios.ts
@@ -281,7 +281,7 @@ export class ModalDatetimepicker {
             );
 
             titleLabel.transform = CGAffineTransformMakeScale(0.8, 0.8);
-            titleLabel.adjustsFontForContentSizeCategory = true;
+            titleLabel.respondsToSelector("adjustsFontForContentSizeCategory") ? titleLabel.adjustsFontForContentSizeCategory = true : null;
             titleLabel.adjustsFontSizeToFitWidth = true;
             titleLabel.layer.masksToBounds = false;
             titleLabel.alpha = 0;


### PR DESCRIPTION
There is a simple problem that breaks iOS compatibility before v10 due to the use of:

https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/1771731-adjustsfontforcontentsizecategor

which is only iOS 10.0+.

The suggestion is to check the iOS version and use this attribute only if the version is 10+.
Something in the line of:

import * as platformModule from "tns-core-modules / platform";

  let sdkVersion = parseInt (platformModule.device.sdkVersion);
sdkVersion> = 10? titleLabel.adjustsFontForContentSizeCategory = true: null;

or similar.
Nativescript mentions gracious degradation:
https://docs.nativescript.org/runtimes/ios/Requirements

but I could not find an elegant way to detect whether a particular attribute exists or not instead of verifying the version of the operating system.

Update:
The "most elegant" way may be using the respondsToSelector:

titleLabel.respondsToSelector ("adjustsFontForContentSizeCategory")? titleLabel.adjustsFontForContentSizeCategory = true: null;

These are the possible solutions to date.

You have my committee where I opted for the second solution.